### PR TITLE
Improve roxygen2 usage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,9 @@ SystemRequirements: C++11
 Imports: 
     Rcpp, RApiSerialize, stringfish (>= 0.15.1)
 LinkingTo: Rcpp, RApiSerialize, stringfish
-RoxygenNote: 7.1.1
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.1.2
 Suggests: knitr, rmarkdown, testthat, dplyr, data.table
 VignetteBuilder: knitr
 Copyright: This package includes code from the 'zstd' library owned by Facebook, Inc. and created by Yann Collet; the 'lz4' library created and owned by Yann Collet; xxHash library created and owned by Yann Collet; and code derived from the 'Blosc' library created and owned by Francesc Alted.  

--- a/R/ascii_encoding.r
+++ b/R/ascii_encoding.r
@@ -1,42 +1,43 @@
 #' Z85 Encoding
-#' 
+#'
 #' Encodes binary data (a raw vector) as ascii text using Z85 encoding format
 #' @usage base85_encode(rawdata)
 #' @param rawdata A raw vector
-#' @return A string representation of the raw vector. 
-#' @details 
+#' @return A string representation of the raw vector.
+#' @details
 #' Z85 is a binary to ascii encoding format created by Pieter Hintjens in 2010 and is part of the ZeroMQ RFC.
 #' The encoding has a dictionary using 85 out of 94 printable ASCII characters.
 #' There are other base 85 encoding schemes, including Ascii85, which is popularized and used by Adobe.
 #' Z85 is distinguished by its choice of dictionary, which is suitable for easier inclusion into source code for many programming languages.
 #' The dictionary excludes all quote marks and other control characters, and requires no special treatment in R and most other languages.
 #' Note: although the official specification restricts input length to multiples of four bytes, the implementation here works with any input length.
-#' The overhead (extra bytes used relative to binary) is 25\%. In comparison, base 64 encoding has an overhead of 33.33\%.
+#' The overhead (extra bytes used relative to binary) is 25%. In comparison, base 64 encoding has an overhead of 33.33%.
 
 #' @references https://rfc.zeromq.org/spec/32/
 #' @name base85_encode
 NULL
 
 #' Z85 Decoding
-#' 
+#'
 #' Decodes a Z85 encoded string back to binary
 #' @usage base85_decode(encoded_string)
 #' @param encoded_string A string
-#' @return The original raw vector. 
+#' @return The original raw vector.
 #' @name base85_decode
 NULL
 
 #' basE91 Encoding
-#' 
+#'
 #' Encodes binary data (a raw vector) as ascii text using basE91 encoding format
 #' @usage base91_encode(rawdata, quote_character = "\"")
 #' @param rawdata A raw vector
-#' @param quote_character The character to use in the encoding, replacing the double quote character. Must be a single quote "'", double quote "\"" or dash "-". 
-#' @return A string representation of the raw vector. 
-#' @details 
+#' @param quote_character The character to use in the encoding, replacing the double quote character. Must be either a single quote (`"'"`), a double quote
+#'   (`"\""`) or a dash (`"-"`).
+#' @return A string representation of the raw vector.
+#' @details
 #' basE91 (capital E for stylization) is a binary to ascii encoding format created by Joachim Henke in 2005.
-#' The overhead (extra bytes used relative to binary) is 22.97\% on average. In comparison, base 64 encoding has an overhead of 33.33\%.
-#' The original encoding uses a dictionary of 91 out of 94 printable ASCII characters excluding - (dash), \ (backslash) and ' (single quote).
+#' The overhead (extra bytes used relative to binary) is 22.97% on average. In comparison, base 64 encoding has an overhead of 33.33%.
+#' The original encoding uses a dictionary of 91 out of 94 printable ASCII characters excluding `-` (dash), `\` (backslash) and `'` (single quote).
 #' The original encoding does include double quote characters, which are less than ideal for strings in R. Therefore,
 #' you can use the `quote_character` parameter to substitute dash or single quote.
 #' @references http://base91.sourceforge.net/
@@ -49,11 +50,11 @@ base91_encode <- function(rawdata, quote_character = "\"") {
 }
 
 #' basE91 Decoding
-#' 
+#'
 #' Decodes a basE91 encoded string back to binary
 #' @usage base91_decode(encoded_string)
 #' @param encoded_string A string
-#' @return The original raw vector. 
+#' @return The original raw vector.
 base91_decode <- function(encoded_string) {
   stopifnot(length(encoded_string) == 1)
   has_double_quote <- grepl("\"", encoded_string)
@@ -68,13 +69,13 @@ base91_decode <- function(encoded_string) {
 }
 
 #' Encode and compress a file or string
-#' 
-#' A helper function for encoding and compressing a file or string to ascii using `base91_encode` and `qserialize` with the highest compression level. 
+#'
+#' A helper function for encoding and compressing a file or string to ascii using [base91_encode()] and [qserialize()] with the highest compression level.
 #' @usage encode_source(file = NULL, string = NULL, width = 120)
 #' @param file The file to encode (if `string` is not NULL)
 #' @param string The string to encode (if `file` is not NULL)
-#' @param width The output will be broken up into individual strings, with `width` being the longest allowable string. 
-#' @return A CharacterVector in base91 representing the compressed original file or string. 
+#' @param width The output will be broken up into individual strings, with `width` being the longest allowable string.
+#' @return A CharacterVector in base91 representing the compressed original file or string.
 encode_source <- function(file = NULL, string = NULL, width = 120) {
   if(!is.null(file)) {
     n <- file.info(file)$size
@@ -94,14 +95,13 @@ encode_source <- function(file = NULL, string = NULL, width = 120) {
 }
 
 #' Decode a compressed string
-#' 
-#' A helper function for encoding and compressing a file or string to ascii using `base91_encode` and `qserialize` with the highest compression level. 
+#'
+#' A helper function for encoding and compressing a file or string to ascii using [base91_encode()] and [qserialize()] with the highest compression level.
 #' @usage decode_source(string)
 #' @param string The string to decode
-#' @return The original (decoded) string. 
+#' @return The original (decoded) string.
 decode_source <- function(string) {
   x <- paste0(string, collapse = "")
   x <- base91_decode(x)
   qdeserialize(x)
 }
-

--- a/R/qcache.R
+++ b/R/qcache.R
@@ -1,8 +1,8 @@
 #' qcache
-#' 
+#'
 #' Helper function for caching objects for long running tasks
-#' @usage qcache(expr, name, envir=parent.frame(), cache_dir=".cache", 
-#'               clear=FALSE, prompt=TRUE, qsave_params=list(), 
+#' @usage qcache(expr, name, envir=parent.frame(), cache_dir=".cache",
+#'               clear=FALSE, prompt=TRUE, qsave_params=list(),
 #'               qread_params=list())
 #' @param expr The expression to evaluate
 #' @param name The cached expression name (see details)
@@ -12,31 +12,31 @@
 #' @param prompt Whether to prompt before clearing
 #' @param qsave_params Parameters passed to `qsave`
 #' @param qread_params Parameters passed to `qread`
-#' @details 
-#' This is a (very) simple helper function to cache results of long running calculations. There are other packages specializing 
-#' in caching data that are more feature complete. 
-#' 
-#' The evaluated expression is saved with `qsave` in <cache_dir>/<name>.qs. 
-#' If the file already exists instead the expression is not evaluated and the cached result is read using `qread` and returned. 
-#' 
-#' To clear a cached result, you can manually delete the associated `qs` file, or you can call `qcache` with `clear=TRUE`. 
-#' If `prompt` is also `TRUE` a prompt will be given asking you to confirm deletion. 
-#' If `name` is not specified, all cached results in `cache_dir` will be removed. 
-#' @examples 
+#' @details
+#' This is a (very) simple helper function to cache results of long running calculations. There are other packages specializing
+#' in caching data that are more feature complete.
+#'
+#' The evaluated expression is saved with [qsave()] in `<cache_dir>/<name>.qs`.
+#' If the file already exists instead, the expression is not evaluated and the cached result is read using [qread()] and returned.
+#'
+#' To clear a cached result, you can manually delete the associated `.qs` file, or you can call [qcache()] with `clear=TRUE`.
+#' If `prompt` is also `TRUE` a prompt will be given asking you to confirm deletion.
+#' If `name` is not specified, all cached results in `cache_dir` will be removed.
+#' @examples
 #' cache_dir <- tempdir()
-#' 
+#'
 #' a <- 1
 #' b <- 5
-#' 
+#'
 #' # not cached
-#' result <- qcache({a + b}, 
-#'                  name="aplusb", 
+#' result <- qcache({a + b},
+#'                  name="aplusb",
 #'                  cache_dir = cache_dir,
 #'                  qsave_params = list(preset="fast"))
-#' 
+#'
 #' # cached
-#' result <- qcache({a + b}, 
-#'                  name="aplusb", 
+#' result <- qcache({a + b},
+#'                  name="aplusb",
 #'                  cache_dir = cache_dir,
 #'                  qsave_params = list(preset="fast"))
 #'

--- a/R/zz_help_files.R
+++ b/R/zz_help_files.R
@@ -31,9 +31,14 @@ shared_params_save <- function(incl_file = FALSE,
     '@param fd A file descriptor.'[incl_fd],
     '@param preset One of `"fast"`, `"balanced"`, `"high"` (default), `"archive"`, `"uncompressed"` or `"custom"`. See section *Presets* for details.',
     '@param algorithm **Ignored unless `preset = "custom"`.** Compression algorithm used: `"lz4"`, `"zstd"`, `"lz4hc"`, `"zstd_stream"` or `"uncompressed"`.',
-    '@param compress_level **Ignored unless `preset = "custom"`.** The compression level used (default `4`). For lz4, this number must be > 1 (higher is less ',
-      'compressed). For zstd, a number  between `-50` to `22` (higher is more compressed). Higher values tend to have a better compression ratio, while ',
-      'lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.',
+    '@param compress_level **Ignored unless `preset = "custom"`.** The compression level used.',
+      '',
+      '',
+      'For lz4, this number must be > 1 (higher is less compressed).',
+      '',
+      '',
+      'For zstd, a number  between `-50` to `22` (higher is more compressed). Due to the format of qs, there is very little benefit to compression levels > 5 ',
+      'or so.',
     '@param shuffle_control **Ignored unless `preset = "custom"`.** An integer setting the use of byte shuffle compression. A value between `0` and `15` ',
       '(default `15`). See section *Byte shuffling* for details.',
     '@param check_hash Default `TRUE`, compute a hash which can be used to verify file integrity during serialization.')
@@ -307,9 +312,8 @@ NULL
 #' @usage zstd_compress_raw(x, compress_level)
 #'
 #' @param x The object to serialize.
-#' @param compress_level The compression level used (default `4`). A number between `-50` to `22` (higher is more compressed). Higher values tend to have a
-#'   better compression ratio, while lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5
-#'   or so.
+#' @param compress_level The compression level used (default `4`). A number between `-50` to `22` (higher is more compressed). Due to the format of qs, there is
+#'   very little benefit to compression levels > 5 or so.
 #'
 #' @return The compressed data as a raw vector.
 #' @examples

--- a/man/base91_encode.Rd
+++ b/man/base91_encode.Rd
@@ -9,7 +9,8 @@ base91_encode(rawdata, quote_character = "\"")
 \arguments{
 \item{rawdata}{A raw vector}
 
-\item{quote_character}{The character to use in the encoding, replacing the double quote character. Must be a single quote "'", double quote "\"" or dash "-".}
+\item{quote_character}{The character to use in the encoding, replacing the double quote character. Must be either a single quote (\code{"'"}), a double quote
+(\verb{"\\""}) or a dash (\code{"-"}).}
 }
 \value{
 A string representation of the raw vector.
@@ -20,9 +21,9 @@ Encodes binary data (a raw vector) as ascii text using basE91 encoding format
 \details{
 basE91 (capital E for stylization) is a binary to ascii encoding format created by Joachim Henke in 2005.
 The overhead (extra bytes used relative to binary) is 22.97\% on average. In comparison, base 64 encoding has an overhead of 33.33\%.
-The original encoding uses a dictionary of 91 out of 94 printable ASCII characters excluding - (dash), \ (backslash) and ' (single quote).
+The original encoding uses a dictionary of 91 out of 94 printable ASCII characters excluding \code{-} (dash), \verb{\\} (backslash) and \verb{'} (single quote).
 The original encoding does include double quote characters, which are less than ideal for strings in R. Therefore,
-you can use the `quote_character` parameter to substitute dash or single quote.
+you can use the \code{quote_character} parameter to substitute dash or single quote.
 }
 \references{
 http://base91.sourceforge.net/

--- a/man/blosc_shuffle_raw.Rd
+++ b/man/blosc_shuffle_raw.Rd
@@ -7,15 +7,15 @@
 blosc_shuffle_raw(x, bytesofsize)
 }
 \arguments{
-\item{x}{The raw vector}
+\item{x}{A raw vector.}
 
-\item{bytesofsize}{Either 4 or 8}
+\item{bytesofsize}{Either \code{4} or \code{8}.}
 }
 \value{
 The shuffled vector
 }
 \description{
-A function for shuffling a raw vector using BLOSC shuffle routines
+Shuffles a raw vector using BLOSC shuffle routines.
 }
 \examples{
 x <- serialize(1L:1000L, NULL)

--- a/man/blosc_unshuffle_raw.Rd
+++ b/man/blosc_unshuffle_raw.Rd
@@ -7,15 +7,15 @@
 blosc_unshuffle_raw(x, bytesofsize)
 }
 \arguments{
-\item{x}{The raw vector}
+\item{x}{A raw vector.}
 
-\item{bytesofsize}{Either 4 or 8}
+\item{bytesofsize}{Either \code{4} or \code{8}.}
 }
 \value{
-The unshuffled vector
+The unshuffled vector.
 }
 \description{
-A function for un-shuffling a raw vector using BLOSC un-shuffle routines
+Un-shuffles a raw vector using BLOSC un-shuffle routines.
 }
 \examples{
 x <- serialize(1L:1000L, NULL)

--- a/man/catquo.Rd
+++ b/man/catquo.Rd
@@ -7,8 +7,8 @@
 catquo(...)
 }
 \arguments{
-\item{...}{Arguments passed to `cat` function}
+\item{...}{Arguments passed on to \code{\link[=cat]{cat()}}.}
 }
 \description{
-Prints a string with single quotes on a new line
+Prints a string with single quotes on a new line.
 }

--- a/man/decode_source.Rd
+++ b/man/decode_source.Rd
@@ -13,5 +13,5 @@ decode_source(string)
 The original (decoded) string.
 }
 \description{
-A helper function for encoding and compressing a file or string to ascii using `base91_encode` and `qserialize` with the highest compression level.
+A helper function for encoding and compressing a file or string to ascii using \code{\link[=base91_encode]{base91_encode()}} and \code{\link[=qserialize]{qserialize()}} with the highest compression level.
 }

--- a/man/encode_source.Rd
+++ b/man/encode_source.Rd
@@ -7,15 +7,15 @@
 encode_source(file = NULL, string = NULL, width = 120)
 }
 \arguments{
-\item{file}{The file to encode (if `string` is not NULL)}
+\item{file}{The file to encode (if \code{string} is not NULL)}
 
-\item{string}{The string to encode (if `file` is not NULL)}
+\item{string}{The string to encode (if \code{file} is not NULL)}
 
-\item{width}{The output will be broken up into individual strings, with `width` being the longest allowable string.}
+\item{width}{The output will be broken up into individual strings, with \code{width} being the longest allowable string.}
 }
 \value{
 A CharacterVector in base91 representing the compressed original file or string.
 }
 \description{
-A helper function for encoding and compressing a file or string to ascii using `base91_encode` and `qserialize` with the highest compression level.
+A helper function for encoding and compressing a file or string to ascii using \code{\link[=base91_encode]{base91_encode()}} and \code{\link[=qserialize]{qserialize()}} with the highest compression level.
 }

--- a/man/is_big_endian.Rd
+++ b/man/is_big_endian.Rd
@@ -7,11 +7,11 @@
 is_big_endian()
 }
 \value{
-`TRUE` if big endian, `FALSE` if little endian.
+\code{TRUE} if big endian, \code{FALSE} if little endian.
 }
 \description{
-Tests system endianness. Intel and AMD based systems are little endian, and so this function will likely return `FALSE`.
-The `qs` package is not capable of transferring data between systems of different endianness. This should not matter for the large majority of use cases.
+Tests system endianness. Intel and AMD based systems are little endian, and so this function will likely return \code{FALSE}.
+The \code{qs} package is not capable of transferring data between systems of different endianness. This should not matter for the large majority of use cases.
 }
 \examples{
 is_big_endian() # returns FALSE on Intel/AMD systems

--- a/man/lz4_compress_bound.Rd
+++ b/man/lz4_compress_bound.Rd
@@ -7,13 +7,13 @@
 lz4_compress_bound(size)
 }
 \arguments{
-\item{size}{An integer size}
+\item{size}{An integer size.}
 }
 \value{
-maximum compressed size
+Maximum compressed size.
 }
 \description{
-Exports the compress bound function from the lz4 library. Returns the maximum compressed size of an object of length `size`.
+Exports the compress bound function from the lz4 library. Returns the maximum compressed size of an object of length \code{size}.
 }
 \examples{
 lz4_compress_bound(100000)

--- a/man/lz4_compress_raw.Rd
+++ b/man/lz4_compress_raw.Rd
@@ -7,15 +7,15 @@
 lz4_compress_raw(x, compress_level)
 }
 \arguments{
-\item{x}{A Raw Vector}
+\item{x}{The object to serialize.}
 
-\item{compress_level}{The compression level (> 1).}
+\item{compress_level}{The compression level used. A number > 1 (higher is less compressed).}
 }
 \value{
-The compressed data
+The compressed data as a raw vector.
 }
 \description{
-Compression of raw vector. Exports the main lz4 compression function.
+Compresses to a raw vector using the lz4 algorithm. Exports the main lz4 compression function.
 }
 \examples{
 x <- 1:1e6

--- a/man/lz4_decompress_raw.Rd
+++ b/man/lz4_decompress_raw.Rd
@@ -7,13 +7,13 @@
 lz4_decompress_raw(x)
 }
 \arguments{
-\item{x}{A Raw Vector}
+\item{x}{A raw vector.}
 }
 \value{
-The uncompressed data
+The de-serialized object.
 }
 \description{
-Decompresses of raw vector
+Decompresses an lz4 compressed raw vector.
 }
 \examples{
 x <- 1:1e6

--- a/man/qcache.Rd
+++ b/man/qcache.Rd
@@ -4,8 +4,8 @@
 \alias{qcache}
 \title{qcache}
 \usage{
-qcache(expr, name, envir=parent.frame(), cache_dir=".cache", 
-              clear=FALSE, prompt=TRUE, qsave_params=list(), 
+qcache(expr, name, envir=parent.frame(), cache_dir=".cache",
+              clear=FALSE, prompt=TRUE, qsave_params=list(),
               qread_params=list())
 }
 \arguments{
@@ -13,31 +13,31 @@ qcache(expr, name, envir=parent.frame(), cache_dir=".cache",
 
 \item{name}{The cached expression name (see details)}
 
-\item{envir}{The environment to evaluate `expr`}
+\item{envir}{The environment to evaluate \code{expr}}
 
 \item{cache_dir}{The directory to store cached files in}
 
-\item{clear}{Set to `TRUE` to clear the cache (see details)}
+\item{clear}{Set to \code{TRUE} to clear the cache (see details)}
 
 \item{prompt}{Whether to prompt before clearing}
 
-\item{qsave_params}{Parameters passed to `qsave`}
+\item{qsave_params}{Parameters passed to \code{qsave}}
 
-\item{qread_params}{Parameters passed to `qread`}
+\item{qread_params}{Parameters passed to \code{qread}}
 }
 \description{
 Helper function for caching objects for long running tasks
 }
 \details{
-This is a (very) simple helper function to cache results of long running calculations. There are other packages specializing 
-in caching data that are more feature complete. 
+This is a (very) simple helper function to cache results of long running calculations. There are other packages specializing
+in caching data that are more feature complete.
 
-The evaluated expression is saved with `qsave` in <cache_dir>/<name>.qs. 
-If the file already exists instead the expression is not evaluated and the cached result is read using `qread` and returned. 
+The evaluated expression is saved with \code{\link[=qsave]{qsave()}} in \verb{<cache_dir>/<name>.qs}.
+If the file already exists instead, the expression is not evaluated and the cached result is read using \code{\link[=qread]{qread()}} and returned.
 
-To clear a cached result, you can manually delete the associated `qs` file, or you can call `qcache` with `clear=TRUE`. 
-If `prompt` is also `TRUE` a prompt will be given asking you to confirm deletion. 
-If `name` is not specified, all cached results in `cache_dir` will be removed.
+To clear a cached result, you can manually delete the associated \code{.qs} file, or you can call \code{\link[=qcache]{qcache()}} with \code{clear=TRUE}.
+If \code{prompt} is also \code{TRUE} a prompt will be given asking you to confirm deletion.
+If \code{name} is not specified, all cached results in \code{cache_dir} will be removed.
 }
 \examples{
 cache_dir <- tempdir()
@@ -46,14 +46,14 @@ a <- 1
 b <- 5
 
 # not cached
-result <- qcache({a + b}, 
-                 name="aplusb", 
+result <- qcache({a + b},
+                 name="aplusb",
                  cache_dir = cache_dir,
                  qsave_params = list(preset="fast"))
 
 # cached
-result <- qcache({a + b}, 
-                 name="aplusb", 
+result <- qcache({a + b},
+                 name="aplusb",
                  cache_dir = cache_dir,
                  qsave_params = list(preset="fast"))
 

--- a/man/qdeserialize.Rd
+++ b/man/qdeserialize.Rd
@@ -7,18 +7,18 @@
 qdeserialize(x, use_alt_rep=FALSE, strict=FALSE)
 }
 \arguments{
-\item{x}{a raw vector}
+\item{x}{A raw vector.}
 
-\item{use_alt_rep}{Use alt rep when reading in string data. Default: FALSE. (Note: on R versions earlier than 3.5.0, this parameter does nothing.)}
+\item{use_alt_rep}{Use ALTREP when reading in string data (default \code{FALSE}). On R versions prior to 3.5.0, this parameter does nothing.}
 
-\item{strict}{Whether to throw an error or just report a warning (Default: FALSE, report warning)}
+\item{strict}{Whether to throw an error or just report a warning (default: \code{FALSE}, i.e. report warning).}
 }
 \value{
-The de-serialized object
+The de-serialized object.
 }
 \description{
-Reads an object from a fd
+Reads an object from a raw vector.
 }
 \details{
-See `?qeserialize` for additional details and examples.
+See \code{\link[=qserialize]{qserialize()}} for additional details and examples.
 }

--- a/man/qdump.Rd
+++ b/man/qdump.Rd
@@ -7,17 +7,17 @@
 qdump(file)
 }
 \arguments{
-\item{file}{the file name/path.}
+\item{file}{A file name/path.}
 }
 \value{
-The uncompressed serialization
+The uncompressed serialization.
 }
 \description{
-Exports the uncompressed binary serialization to a list of Raw Vectors. For testing purposes and exploratory purposes mainly.
+Exports the uncompressed binary serialization to a list of raw vectors. For testing purposes and exploratory purposes mainly.
 }
 \examples{
-x <- data.frame(int = sample(1e3, replace=TRUE), 
-        num = rnorm(1e3), 
+x <- data.frame(int = sample(1e3, replace=TRUE),
+        num = rnorm(1e3),
         char = randomStrings(1e3), stringsAsFactors = FALSE)
 myfile <- tempfile()
 qsave(x, myfile)

--- a/man/qread.Rd
+++ b/man/qread.Rd
@@ -7,23 +7,23 @@
 qread(file, use_alt_rep=FALSE, strict=FALSE, nthreads=1)
 }
 \arguments{
-\item{file}{the file name/path}
+\item{file}{The file name/path.}
 
-\item{use_alt_rep}{Use alt rep when reading in string data. Default: FALSE. (Note: on R versions earlier than 3.5.0, this parameter does nothing.)}
+\item{use_alt_rep}{Use ALTREP when reading in string data (default \code{FALSE}). On R versions prior to 3.5.0, this parameter does nothing.}
 
-\item{strict}{Whether to throw an error or just report a warning (Default: FALSE, report warning)}
+\item{strict}{Whether to throw an error or just report a warning (default: \code{FALSE}, i.e. report warning).}
 
-\item{nthreads}{Number of threads to use. Default 1.}
+\item{nthreads}{Number of threads to use. Default \code{1}.}
 }
 \value{
-The de-serialized object
+The de-serialized object.
 }
 \description{
-Reads an object in a file serialized to disk
+Reads an object in a file serialized to disk.
 }
 \examples{
-x <- data.frame(int = sample(1e3, replace=TRUE), 
-        num = rnorm(1e3), 
+x <- data.frame(int = sample(1e3, replace=TRUE),
+        num = rnorm(1e3),
         char = randomStrings(1e3), stringsAsFactors = FALSE)
 myfile <- tempfile()
 qsave(x, myfile)

--- a/man/qread_fd.Rd
+++ b/man/qread_fd.Rd
@@ -7,18 +7,18 @@
 qread_fd(fd, use_alt_rep=FALSE, strict=FALSE)
 }
 \arguments{
-\item{fd}{A file descriptor}
+\item{fd}{A file descriptor.}
 
-\item{use_alt_rep}{Use alt rep when reading in string data. Default: FALSE. (Note: on R versions earlier than 3.5.0, this parameter does nothing.)}
+\item{use_alt_rep}{Use ALTREP when reading in string data (default \code{FALSE}). On R versions prior to 3.5.0, this parameter does nothing.}
 
-\item{strict}{Whether to throw an error or just report a warning (Default: FALSE, report warning)}
+\item{strict}{Whether to throw an error or just report a warning (default: \code{FALSE}, i.e. report warning).}
 }
 \value{
-The de-serialized object
+The de-serialized object.
 }
 \description{
-Reads an object from a file descriptor
+Reads an object from a file descriptor.
 }
 \details{
-See `?qsave_fd` for additional details and examples.
+See \code{\link[=qsave_fd]{qsave_fd()}} for additional details and examples.
 }

--- a/man/qread_handle.Rd
+++ b/man/qread_handle.Rd
@@ -7,18 +7,18 @@
 qread_handle(handle, use_alt_rep=FALSE, strict=FALSE)
 }
 \arguments{
-\item{handle}{A windows handle external pointer}
+\item{handle}{A windows handle external pointer.}
 
-\item{use_alt_rep}{Use alt rep when reading in string data. Default: FALSE. (Note: on R versions earlier than 3.5.0, this parameter does nothing.)}
+\item{use_alt_rep}{Use ALTREP when reading in string data (default \code{FALSE}). On R versions prior to 3.5.0, this parameter does nothing.}
 
-\item{strict}{Whether to throw an error or just report a warning (Default: FALSE, report warning)}
+\item{strict}{Whether to throw an error or just report a warning (default: \code{FALSE}, i.e. report warning).}
 }
 \value{
-The de-serialized object
+The de-serialized object.
 }
 \description{
-Reads an object from a windows handle
+Reads an object from a windows handle.
 }
 \details{
-See `?qsave_handle` for additional details and examples.
+See \code{\link[=qsave_handle]{qsave_handle()}} for additional details and examples.
 }

--- a/man/qread_ptr.Rd
+++ b/man/qread_ptr.Rd
@@ -7,17 +7,17 @@
 qread_ptr(pointer, length, use_alt_rep=FALSE, strict=FALSE)
 }
 \arguments{
-\item{pointer}{An external pointer to memory}
+\item{pointer}{An external pointer to memory.}
 
-\item{length}{the length of the object in memory}
+\item{length}{The length of the object in memory.}
 
-\item{use_alt_rep}{Use alt rep when reading in string data. Default: FALSE. (Note: on R versions earlier than 3.5.0, this parameter does nothing.)}
+\item{use_alt_rep}{Use ALTREP when reading in string data (default \code{FALSE}). On R versions prior to 3.5.0, this parameter does nothing.}
 
-\item{strict}{Whether to throw an error or just report a warning (Default: FALSE, report warning)}
+\item{strict}{Whether to throw an error or just report a warning (default: \code{FALSE}, i.e. report warning).}
 }
 \value{
-The de-serialized object
+The de-serialized object.
 }
 \description{
-Reads an object from a external pointer
+Reads an object from an external pointer.
 }

--- a/man/qreadm.Rd
+++ b/man/qreadm.Rd
@@ -23,7 +23,7 @@ Nothing is explicitly returned, but the function will load the saved objects int
 Reads an object in a file serialized to disk using qsavem.
 }
 \details{
-This function extends qread to replicate the functionality of base::load to load multiple saved objects into your workspace. `qloadm` and `qsavem` are alias of the same function.
+This function extends qread to replicate the functionality of base::load to load multiple saved objects into your workspace. \code{qloadm} and \code{qsavem} are alias of the same function.
 }
 \examples{
 x1 <- data.frame(int = sample(1e3, replace=TRUE), 

--- a/man/qsave.Rd
+++ b/man/qsave.Rd
@@ -4,56 +4,64 @@
 \alias{qsave}
 \title{qsave}
 \usage{
-qsave(x, file, 
-preset = "high", algorithm = "zstd", compress_level = 4L, 
+qsave(x, file,
+preset = "high", algorithm = "zstd", compress_level = 4L,
 shuffle_control = 15L, check_hash=TRUE, nthreads = 1)
 }
 \arguments{
-\item{x}{the object to serialize.}
+\item{x}{The object to serialize.}
 
-\item{file}{the file name/path.}
+\item{file}{The file name/path.}
 
-\item{preset}{One of "fast", "high" (default), "archive", "uncompressed" or "custom". See details.}
+\item{preset}{One of \code{"fast"}, \code{"balanced"}, \code{"high"} (default), \code{"archive"}, \code{"uncompressed"} or \code{"custom"}. See section \emph{Presets} for details.}
 
-\item{algorithm}{Compression algorithm used: "lz4", "zstd", "lz4hc", "zstd_stream" or "uncompressed".}
+\item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{The compression level used (Default 4). For lz4, this number must be > 1 (higher is less compressed). For zstd, a number between -50 to 22 (higher is more compressed).}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
+compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
+lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
 
-\item{shuffle_control}{An integer setting the use of byte shuffle compression. A value between 0 and 15 (Default 15). See details.}
+\item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
+(default \code{15}). See section \emph{Byte shuffling} for details.}
 
-\item{check_hash}{Default TRUE, compute a hash which can be used to verify file integrity during serialization}
+\item{check_hash}{Default \code{TRUE}, compute a hash which can be used to verify file integrity during serialization.}
 
-\item{nthreads}{Number of threads to use. Default 1.}
+\item{nthreads}{Number of threads to use. Default \code{1}.}
 }
 \value{
-The total number of bytes written to the file (returned invisibly)
+The total number of bytes written to the file (returned invisibly).
 }
 \description{
 Saves (serializes) an object to disk.
 }
 \details{
-This function serializes and compresses R objects using block compresion with the option of byte shuffling.
-There are lots of possible parameters. This function exposes three parameters related to compression level and byte shuffling.
-
-`compress_level` - Higher values tend to have a better compression ratio, while lower values/negative values tend to be quicker.
-Due to the format of qs, there is very little benefit to compression levels > 5 or so.
-
-`shuffle_control` - This sets which numerical R object types are subject to byte shuffling.
-Generally speaking, the more ordered/sequential an object is (e.g., `1:1e7`), the larger the potential benefit of byte shuffling.
-It is not uncommon to have several orders magnitude benefit to compression ratio or compression speed. The more random an object is (e.g., `rnorm(1e7)`), 
-the less potential benefit there is, even negative benefit is possible. Integer vectors almost always benefit from byte shuffling whereas the results for numeric vectors are mixed.
-To control block shuffling, add +1 to the parameter for logical vectors, +2 for integer vectors, +4 for numeric vectors and/or +8 for complex vectors.
-
-The `preset` parameter has several different combination of parameter sets that are performant over a large variety of data.
-The `algorithm` parameter, `compression_level` and `shuffle_control` 
-parameters are ignored unless `preset` is "custom". "fast" preset: algorithm lz4, compress_level 100, shuffle_control 0.
-"balanced" preset: algorithm lz4, compress_level 1, shuffle_control 15.
-"high" preset: algorithm zstd, compress_level 4, shuffle_control 15.
-"archive" preset: algorithm zstd_stream, compress_level 14, shuffle_control 15. (zstd_stream is currently single threaded only)
+This function serializes and compresses R objects using block compression with the option of byte shuffling.
 }
+\section{Presets}{
+There are lots of possible parameters. To simplify usage, there are four main presets that are performant over a large variety of data:
+\itemize{
+\item \strong{\code{"fast"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 100} and \code{shuffle_control = 0}.
+\item \strong{\code{"balanced"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 1} and \code{shuffle_control = 15}.
+\item \strong{\code{"high"}} is a shortcut for \code{algorithm = "zstd"}, \code{compress_level = 4} and \code{shuffle_control = 15}.
+\item \strong{\code{"archive"}} is a shortcut for \code{algorithm = "zstd_stream"}, \code{compress_level = 14} and \code{shuffle_control = 15}. (\code{zstd_stream} is currently
+single-threaded only)
+}
+
+To gain more control over compression level and byte shuffling, set \code{preset = "custom"}, in which case the individual parameters \code{algorithm},
+\code{compress_level} and \code{shuffle_control} are actually regarded.
+}
+
+\section{Byte shuffling}{
+The parameter \code{shuffle_control} defines which numerical R object types are subject to \emph{byte shuffling}. Generally speaking, the more ordered/sequential an
+object is (e.g., \code{1:1e7}), the larger the potential benefit of byte shuffling. It is not uncommon to improve compression ratio or compression speed by
+several orders of magnitude. The more random an object is (e.g., \code{rnorm(1e7)}), the less potential benefit there is, even negative benefit is possible.
+Integer vectors almost always benefit from byte shuffling, whereas the results for numeric vectors are mixed. To control block shuffling, add +1 to the
+parameter for logical vectors, +2 for integer vectors, +4 for numeric vectors and/or +8 for complex vectors.
+}
+
 \examples{
-x <- data.frame(int = sample(1e3, replace=TRUE), 
-        num = rnorm(1e3), 
+x <- data.frame(int = sample(1e3, replace=TRUE),
+        num = rnorm(1e3),
         char = randomStrings(1e3), stringsAsFactors = FALSE)
 myfile <- tempfile()
 qsave(x, myfile)

--- a/man/qsave.Rd
+++ b/man/qsave.Rd
@@ -17,9 +17,12 @@ shuffle_control = 15L, check_hash=TRUE, nthreads = 1)
 
 \item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
-compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
-lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used.
+
+For lz4, this number must be > 1 (higher is less compressed).
+
+For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Due to the format of qs, there is very little benefit to compression levels > 5
+or so.}
 
 \item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
 (default \code{15}). See section \emph{Byte shuffling} for details.}

--- a/man/qsave_fd.Rd
+++ b/man/qsave_fd.Rd
@@ -4,32 +4,56 @@
 \alias{qsave_fd}
 \title{qsave_fd}
 \usage{
-qsave_fd(x, fd, 
-preset = "high", algorithm = "zstd", compress_level = 4L, 
+qsave_fd(x, fd,
+preset = "high", algorithm = "zstd", compress_level = 4L,
 shuffle_control = 15L, check_hash=TRUE)
 }
 \arguments{
-\item{x}{the object to serialize.}
+\item{x}{The object to serialize.}
 
-\item{fd}{A file descriptor}
+\item{fd}{A file descriptor.}
 
-\item{preset}{One of "fast", "balanced" , "high" (default), "archive", "uncompressed" or "custom". See details.}
+\item{preset}{One of \code{"fast"}, \code{"balanced"}, \code{"high"} (default), \code{"archive"}, \code{"uncompressed"} or \code{"custom"}. See section \emph{Presets} for details.}
 
-\item{algorithm}{Compression algorithm used: "lz4", "zstd", "lz4hc", "zstd_stream" or "uncompressed".}
+\item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{The compression level used (Default 4). For lz4, this number must be > 1 (higher is less compressed). For zstd, a number between -50 to 22 (higher is more compressed).}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
+compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
+lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
 
-\item{shuffle_control}{An integer setting the use of byte shuffle compression. A value between 0 and 15 (Default 15). See details.}
+\item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
+(default \code{15}). See section \emph{Byte shuffling} for details.}
 
-\item{check_hash}{Default TRUE, compute a hash which can be used to verify file integrity during serialization}
+\item{check_hash}{Default \code{TRUE}, compute a hash which can be used to verify file integrity during serialization.}
 }
 \value{
-the number of bytes serialized (returned invisibly)
+The total number of bytes written to the file (returned invisibly).
 }
 \description{
-Saves an object to a file descriptor
+Saves an object to a file descriptor.
 }
 \details{
-This function serializes and compresses an R object to a stream using a file descriptor
-If your data is important, make sure you know what happens on the other side of the pipe. See examples for usage.
+This function serializes and compresses R objects using block compression with the option of byte shuffling.
 }
+\section{Presets}{
+There are lots of possible parameters. To simplify usage, there are four main presets that are performant over a large variety of data:
+\itemize{
+\item \strong{\code{"fast"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 100} and \code{shuffle_control = 0}.
+\item \strong{\code{"balanced"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 1} and \code{shuffle_control = 15}.
+\item \strong{\code{"high"}} is a shortcut for \code{algorithm = "zstd"}, \code{compress_level = 4} and \code{shuffle_control = 15}.
+\item \strong{\code{"archive"}} is a shortcut for \code{algorithm = "zstd_stream"}, \code{compress_level = 14} and \code{shuffle_control = 15}. (\code{zstd_stream} is currently
+single-threaded only)
+}
+
+To gain more control over compression level and byte shuffling, set \code{preset = "custom"}, in which case the individual parameters \code{algorithm},
+\code{compress_level} and \code{shuffle_control} are actually regarded.
+}
+
+\section{Byte shuffling}{
+The parameter \code{shuffle_control} defines which numerical R object types are subject to \emph{byte shuffling}. Generally speaking, the more ordered/sequential an
+object is (e.g., \code{1:1e7}), the larger the potential benefit of byte shuffling. It is not uncommon to improve compression ratio or compression speed by
+several orders of magnitude. The more random an object is (e.g., \code{rnorm(1e7)}), the less potential benefit there is, even negative benefit is possible.
+Integer vectors almost always benefit from byte shuffling, whereas the results for numeric vectors are mixed. To control block shuffling, add +1 to the
+parameter for logical vectors, +2 for integer vectors, +4 for numeric vectors and/or +8 for complex vectors.
+}
+

--- a/man/qsave_fd.Rd
+++ b/man/qsave_fd.Rd
@@ -17,9 +17,12 @@ shuffle_control = 15L, check_hash=TRUE)
 
 \item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
-compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
-lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used.
+
+For lz4, this number must be > 1 (higher is less compressed).
+
+For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Due to the format of qs, there is very little benefit to compression levels > 5
+or so.}
 
 \item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
 (default \code{15}). See section \emph{Byte shuffling} for details.}

--- a/man/qsave_handle.Rd
+++ b/man/qsave_handle.Rd
@@ -4,32 +4,56 @@
 \alias{qsave_handle}
 \title{qsave_handle}
 \usage{
-qsave_handle(x, handle, 
-preset = "high", algorithm = "zstd", compress_level = 4L, 
+qsave_handle(x, handle,
+preset = "high", algorithm = "zstd", compress_level = 4L,
 shuffle_control = 15L, check_hash=TRUE)
 }
 \arguments{
-\item{x}{the object to serialize.}
+\item{x}{The object to serialize.}
 
-\item{handle}{A windows handle external pointer}
+\item{handle}{A windows handle external pointer.}
 
-\item{preset}{One of "fast", "balanced" , "high" (default), "archive", "uncompressed" or "custom". See details.}
+\item{preset}{One of \code{"fast"}, \code{"balanced"}, \code{"high"} (default), \code{"archive"}, \code{"uncompressed"} or \code{"custom"}. See section \emph{Presets} for details.}
 
-\item{algorithm}{Compression algorithm used: "lz4", "zstd", "lz4hc", "zstd_stream" or "uncompressed".}
+\item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{The compression level used (Default 4). For lz4, this number must be > 1 (higher is less compressed). For zstd, a number between -50 to 22 (higher is more compressed).}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
+compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
+lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
 
-\item{shuffle_control}{An integer setting the use of byte shuffle compression. A value between 0 and 15 (Default 15). See details.}
+\item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
+(default \code{15}). See section \emph{Byte shuffling} for details.}
 
-\item{check_hash}{Default TRUE, compute a hash which can be used to verify file integrity during serialization}
+\item{check_hash}{Default \code{TRUE}, compute a hash which can be used to verify file integrity during serialization.}
 }
 \value{
-the number of bytes serialized (returned invisibly)
+The total number of bytes written to the file (returned invisibly).
 }
 \description{
-Saves an object to a windows handle
+Saves an object to a windows handle.
 }
 \details{
-This function serializes and compresses an R object to a stream using a file descriptor
-If your data is important, make sure you know what happens on the other side of the pipe. See examples for usage.
+This function serializes and compresses R objects using block compression with the option of byte shuffling.
 }
+\section{Presets}{
+There are lots of possible parameters. To simplify usage, there are four main presets that are performant over a large variety of data:
+\itemize{
+\item \strong{\code{"fast"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 100} and \code{shuffle_control = 0}.
+\item \strong{\code{"balanced"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 1} and \code{shuffle_control = 15}.
+\item \strong{\code{"high"}} is a shortcut for \code{algorithm = "zstd"}, \code{compress_level = 4} and \code{shuffle_control = 15}.
+\item \strong{\code{"archive"}} is a shortcut for \code{algorithm = "zstd_stream"}, \code{compress_level = 14} and \code{shuffle_control = 15}. (\code{zstd_stream} is currently
+single-threaded only)
+}
+
+To gain more control over compression level and byte shuffling, set \code{preset = "custom"}, in which case the individual parameters \code{algorithm},
+\code{compress_level} and \code{shuffle_control} are actually regarded.
+}
+
+\section{Byte shuffling}{
+The parameter \code{shuffle_control} defines which numerical R object types are subject to \emph{byte shuffling}. Generally speaking, the more ordered/sequential an
+object is (e.g., \code{1:1e7}), the larger the potential benefit of byte shuffling. It is not uncommon to improve compression ratio or compression speed by
+several orders of magnitude. The more random an object is (e.g., \code{rnorm(1e7)}), the less potential benefit there is, even negative benefit is possible.
+Integer vectors almost always benefit from byte shuffling, whereas the results for numeric vectors are mixed. To control block shuffling, add +1 to the
+parameter for logical vectors, +2 for integer vectors, +4 for numeric vectors and/or +8 for complex vectors.
+}
+

--- a/man/qsave_handle.Rd
+++ b/man/qsave_handle.Rd
@@ -17,9 +17,12 @@ shuffle_control = 15L, check_hash=TRUE)
 
 \item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
-compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
-lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used.
+
+For lz4, this number must be > 1 (higher is less compressed).
+
+For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Due to the format of qs, there is very little benefit to compression levels > 5
+or so.}
 
 \item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
 (default \code{15}). See section \emph{Byte shuffling} for details.}

--- a/man/qserialize.Rd
+++ b/man/qserialize.Rd
@@ -15,9 +15,12 @@ shuffle_control = 15L, check_hash=TRUE)
 
 \item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
-compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
-lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used.
+
+For lz4, this number must be > 1 (higher is less compressed).
+
+For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Due to the format of qs, there is very little benefit to compression levels > 5
+or so.}
 
 \item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
 (default \code{15}). See section \emph{Byte shuffling} for details.}

--- a/man/qserialize.Rd
+++ b/man/qserialize.Rd
@@ -4,27 +4,54 @@
 \alias{qserialize}
 \title{qserialize}
 \usage{
-qserialize(x, preset = "high", 
-algorithm = "zstd", compress_level = 4L, 
+qserialize(x, preset = "high",
+algorithm = "zstd", compress_level = 4L,
 shuffle_control = 15L, check_hash=TRUE)
 }
 \arguments{
-\item{x}{the object to serialize.}
+\item{x}{The object to serialize.}
 
-\item{preset}{One of "fast", "balanced", "high" (default), "archive", "uncompressed" or "custom". See details.}
+\item{preset}{One of \code{"fast"}, \code{"balanced"}, \code{"high"} (default), \code{"archive"}, \code{"uncompressed"} or \code{"custom"}. See section \emph{Presets} for details.}
 
-\item{algorithm}{Compression algorithm used: "lz4", "zstd", "lz4hc", "zstd_stream" or "uncompressed".}
+\item{algorithm}{\strong{Ignored unless \code{preset = "custom"}.} Compression algorithm used: \code{"lz4"}, \code{"zstd"}, \code{"lz4hc"}, \code{"zstd_stream"} or \code{"uncompressed"}.}
 
-\item{compress_level}{The compression level used (Default 4). For lz4, this number must be > 1 (higher is less compressed). For zstd, a number between -50 to 22 (higher is more compressed).}
+\item{compress_level}{\strong{Ignored unless \code{preset = "custom"}.} The compression level used (default \code{4}). For lz4, this number must be > 1 (higher is less
+compressed). For zstd, a number  between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a better compression ratio, while
+lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5 or so.}
 
-\item{shuffle_control}{An integer setting the use of byte shuffle compression. A value between 0 and 15 (Default 15). See details.}
+\item{shuffle_control}{\strong{Ignored unless \code{preset = "custom"}.} An integer setting the use of byte shuffle compression. A value between \code{0} and \code{15}
+(default \code{15}). See section \emph{Byte shuffling} for details.}
 
-\item{check_hash}{Default TRUE, compute a hash which can be used to verify file integrity during serialization}
+\item{check_hash}{Default \code{TRUE}, compute a hash which can be used to verify file integrity during serialization.}
+}
+\value{
+A raw vector.
 }
 \description{
-Saves an object to a raw vector
+Saves an object to a raw vector.
 }
 \details{
-This function serializes and compresses an R object to a raw vctor
-If your data is important, make sure you know what happens on the other side of the pipe. See examples for usage.
+This function serializes and compresses R objects using block compression with the option of byte shuffling.
 }
+\section{Presets}{
+There are lots of possible parameters. To simplify usage, there are four main presets that are performant over a large variety of data:
+\itemize{
+\item \strong{\code{"fast"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 100} and \code{shuffle_control = 0}.
+\item \strong{\code{"balanced"}} is a shortcut for \code{algorithm = "lz4"}, \code{compress_level = 1} and \code{shuffle_control = 15}.
+\item \strong{\code{"high"}} is a shortcut for \code{algorithm = "zstd"}, \code{compress_level = 4} and \code{shuffle_control = 15}.
+\item \strong{\code{"archive"}} is a shortcut for \code{algorithm = "zstd_stream"}, \code{compress_level = 14} and \code{shuffle_control = 15}. (\code{zstd_stream} is currently
+single-threaded only)
+}
+
+To gain more control over compression level and byte shuffling, set \code{preset = "custom"}, in which case the individual parameters \code{algorithm},
+\code{compress_level} and \code{shuffle_control} are actually regarded.
+}
+
+\section{Byte shuffling}{
+The parameter \code{shuffle_control} defines which numerical R object types are subject to \emph{byte shuffling}. Generally speaking, the more ordered/sequential an
+object is (e.g., \code{1:1e7}), the larger the potential benefit of byte shuffling. It is not uncommon to improve compression ratio or compression speed by
+several orders of magnitude. The more random an object is (e.g., \code{rnorm(1e7)}), the less potential benefit there is, even negative benefit is possible.
+Integer vectors almost always benefit from byte shuffling, whereas the results for numeric vectors are mixed. To control block shuffling, add +1 to the
+parameter for logical vectors, +2 for integer vectors, +4 for numeric vectors and/or +8 for complex vectors.
+}
+

--- a/man/starnames.Rd
+++ b/man/starnames.Rd
@@ -5,7 +5,7 @@
 \alias{starnames}
 \title{Official list of IAU Star Names}
 \format{
-A `data.frame` with official IAU star names and several properties, such as coordinates.
+A \code{data.frame} with official IAU star names and several properties, such as coordinates.
 }
 \source{
 \href{https://www.iau.org/public/themes/naming_stars/}{Naming Stars | International Astronomical Union.}
@@ -22,7 +22,7 @@ updated as of June 1, 2018.
 data(starnames)
 }
 \references{
-E Mamajek et. al. (2018), 
+E Mamajek et. al. (2018),
 \emph{WG Triennial Report (2015-2018) - Star Names}, Reports on Astronomy, 22 Mar 2018.
 }
 \keyword{datasets}

--- a/man/zstd_compress_bound.Rd
+++ b/man/zstd_compress_bound.Rd
@@ -13,7 +13,7 @@ zstd_compress_bound(size)
 maximum compressed size
 }
 \description{
-Exports the compress bound function from the zstd library. Returns the maximum compressed size of an object of length `size`.
+Exports the compress bound function from the zstd library. Returns the maximum compressed size of an object of length \code{size}.
 }
 \examples{
 zstd_compress_bound(100000)

--- a/man/zstd_compress_raw.Rd
+++ b/man/zstd_compress_raw.Rd
@@ -7,15 +7,17 @@
 zstd_compress_raw(x, compress_level)
 }
 \arguments{
-\item{x}{A Raw Vector}
+\item{x}{The object to serialize.}
 
-\item{compress_level}{The compression level (-50 to 22)}
+\item{compress_level}{The compression level used (default \code{4}). A number between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a
+better compression ratio, while lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5
+or so.}
 }
 \value{
-The compressed data
+The compressed data as a raw vector.
 }
 \description{
-Compression of raw vector. Exports the main zstd compression function.
+Compresses to a raw vector using the zstd algorithm. Exports the main zstd compression function.
 }
 \examples{
 x <- 1:1e6

--- a/man/zstd_compress_raw.Rd
+++ b/man/zstd_compress_raw.Rd
@@ -9,9 +9,8 @@ zstd_compress_raw(x, compress_level)
 \arguments{
 \item{x}{The object to serialize.}
 
-\item{compress_level}{The compression level used (default \code{4}). A number between \code{-50} to \code{22} (higher is more compressed). Higher values tend to have a
-better compression ratio, while lower/negative values tend to be quicker. Due to the format of qs, there is very little benefit to compression levels > 5
-or so.}
+\item{compress_level}{The compression level used (default \code{4}). A number between \code{-50} to \code{22} (higher is more compressed). Due to the format of qs, there is
+very little benefit to compression levels > 5 or so.}
 }
 \value{
 The compressed data as a raw vector.

--- a/man/zstd_decompress_raw.Rd
+++ b/man/zstd_decompress_raw.Rd
@@ -7,13 +7,13 @@
 zstd_decompress_raw(x)
 }
 \arguments{
-\item{x}{A Raw Vector}
+\item{x}{A raw vector.}
 }
 \value{
-The uncompressed data
+The de-serialized object.
 }
 \description{
-Decompresses of raw vector
+Decompresses a zstd compressed raw vector.
 }
 \examples{
 x <- 1:1e6


### PR DESCRIPTION
This PR relies on various modern roxygen2 features to simplify and streamline documentation and reduce duplications. There were also a bunch of documentation errors/mistakes that this PR fixes as well as various spelling harmonizations.

Note that unfortunately we can't use `@inheritParams` [since](https://github.com/r-lib/roxygen2/issues/836#issuecomment-513476356)

> roxygen2 doesn't parse the usage block, so it doesn't know what the usage is, and hence it doesn't find any parameters to inherit.

Instead we use [`@eval`](https://roxygen2.r-lib.org/articles/rd.html#evaluating-arbitrary-code) to minimize duplication.

Also note that Markdown support in roxygen2 documentation tags is now enabled globally for the whole package which means percentage signs (`%`) mustn't be escaped anymore.